### PR TITLE
Add support for --names to provide custom labels

### DIFF
--- a/tests/test_image_generator.py
+++ b/tests/test_image_generator.py
@@ -12,7 +12,7 @@ class TestImageGenerator(unittest.TestCase):
 
     def test_generate_image(self):
         data = {
-            748868.53: {
+            '748868.53 req/s': {
                 50: 250e-6,
                 75: 491e-6,
                 90: 700e-6,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,8 +12,8 @@ class TestParser(unittest.TestCase):
 
     def test_parse_wrk_output(self):
         expected_results = {
-            'wrk': ({748868.53: {50: 250e-6, 75: 491e-6, 90: 700e-6, 99: 5.8e-3}}, 'localhost:8080'),
-            'localhost': ({643.28: {50: 15.25e-3, 75: 15.46e-3, 90: 15.79e-3, 99: 22.67e-3, }}, '127.0.0.1:5000')
+            'wrk': ({'748868.53 req/s': {50: 250e-6, 75: 491e-6, 90: 700e-6, 99: 5.8e-3}}, 'localhost:8080'),
+            'localhost': ({'643.28 req/s': {50: 15.25e-3, 75: 15.46e-3, 90: 15.79e-3, 99: 22.67e-3, }}, '127.0.0.1:5000')
         }
         for path in glob('example/mono/wrk/*'):
             path = Path(path)
@@ -25,8 +25,8 @@ class TestParser(unittest.TestCase):
 
     def test_parse_wrk2_output(self):
         expected_results = {
-            'issue1': {'website': '127.0.0.1:8080', 'results': {1996.65: {50.0: 0.001183, 99.9: 0.03074}}},
-            'wrk2': {'website': '127.0.0.1:80', 'results': {2000.28: {50.0: 0.006671, 99.9: 0.0123}}},
+            'issue1': {'website': '127.0.0.1:8080', 'results': {'1996.65 req/s': {50.0: 0.001183, 99.9: 0.03074}}},
+            'wrk2': {'website': '127.0.0.1:80', 'results': {'2000.28 req/s': {50.0: 0.006671, 99.9: 0.0123}}},
         }
         for path in glob('example/mono/wrk2/*'):
             path = Path(path)
@@ -58,8 +58,9 @@ class TestParser(unittest.TestCase):
         self.assertEqual(str, type(wrk_output))
         self.assertEqual(2, len(parsed[0]))
         for i in [1, 2]:
-            self.assertIn(i, parsed[0])
-            self.assertGreater(len(parsed[0][i]), 20)
+            label = "{} req/s".format(float(i))
+            self.assertIn(label, parsed[0])
+            self.assertGreater(len(parsed[0][label]), 20)
 
 
 if __name__ == '__main__':

--- a/wrk2img/image_generator.py
+++ b/wrk2img/image_generator.py
@@ -15,17 +15,17 @@ class ImageGenerator:
         self.background = '#' + background
         self.scale = 'log' if log_scale else 'linear'
 
-    def generate_and_save_image(self, data: Dict[float, Dict[float, float]], website: str, output: Path):
+    def generate_and_save_image(self, data: Dict[str, Dict[float, float]], website: str, output: Path):
         figure = self.generate_image(data, website)
         self.save_image(figure, output)
 
-    def generate_image(self, data: Dict[float, Dict[float, float]], website: str) -> Figure:
+    def generate_image(self, data: Dict[str, Dict[float, float]], website: str) -> Figure:
         fig = plt.figure(figsize=(7, 5))
         ax = fig.add_subplot(1, 1, 1)  # type: Axes
         for label, values in data.items():
             x, y = zip(*sorted(values.items()))
             y_ms = [v * 1000 for v in y]
-            ax.plot(x, y_ms, label=str(label) + ' req/s')
+            ax.plot(x, y_ms, label=label)
         if self.scale == 'linear':
             ax.set_ylim(bottom=max(ax.get_ylim()[0], 0))
         ax.legend()

--- a/wrk2img/main.py
+++ b/wrk2img/main.py
@@ -17,6 +17,7 @@ def parse_args():
     parser.add_argument("-b", "--background", type=color, default="FFFFFF", metavar="FFFFFF", help="background color")
     parser.add_argument("-t", "--transparent", action="store_true", help="use a transparent background")
     parser.add_argument("-l", "--log", action="store_true", help="use a log scale")
+    parser.add_argument("-n", "--names", default=None, help="Comma-separated curve names in the order they are given")
     return parser.parse_args()
 
 
@@ -26,7 +27,8 @@ def cli():
     parser = Parser()
     image_generator = ImageGenerator(transparent=args.transparent, background=args.background, log_scale=args.log)
 
-    data, website = parser.parse_stdin()
+    curve_names = args.names.split(",") if args.names is not None else []
+    data, website = parser.parse_stdin(curve_names=curve_names)
     image_generator.generate_and_save_image(data, website, args.output)
 
 

--- a/wrk2img/parser.py
+++ b/wrk2img/parser.py
@@ -21,9 +21,9 @@ class UnitMultiplier(Enum):
 
 
 class Parser:
-    def parse_stdin(self) -> Tuple[Dict[float, Dict[float, float]], str]:
+    def parse_stdin(self, curve_names: list = None) -> Tuple[Dict[str, Dict[float, float]], str]:
         wrk_ouput = self.read_stdin()
-        parsed_wrk_output = self.parse_wrk_output(wrk_ouput)
+        parsed_wrk_output = self.parse_wrk_output(wrk_ouput, curve_names=curve_names)
         return parsed_wrk_output
 
     def read_stdin(self) -> str:
@@ -34,25 +34,29 @@ class Parser:
         std_concat = "".join(std)
         return std_concat
 
-    def parse_wrk_output(self, wrk_output: str) -> Tuple[Dict[float, Dict[float, float]], str]:
-        parsed = {}  # type: Dict[float, Dict[float, float]]
+    def parse_wrk_output(self, wrk_output: str, curve_names: list = None) -> Tuple[Dict[str, Dict[float, float]], str]:
+        parsed = {}  # type: Dict[str, Dict[float, float]]
         websites = []
         all_wrk_output = re.findall(RegexLibrary.split.value, wrk_output, flags=re.DOTALL)
-        for single_wrk_output in all_wrk_output:
+        for i, single_wrk_output in enumerate(all_wrk_output):
             websites.append(re.search(RegexLibrary.website.value, single_wrk_output).group(1))
             req_s = float(re.search(RegexLibrary.req_s.value, single_wrk_output).group(1))
-            parsed[req_s] = {}
+            if curve_names is not None and i < len(curve_names):
+                label = curve_names[i]
+            else:
+                label = "{} req/s".format(req_s)
+            parsed[label] = {}
             # parse latency
             for matches in re.findall(RegexLibrary.latency.value, single_wrk_output):
                 percentile, result, unit = matches
                 scaled_result = round(float(result) * UnitMultiplier[unit].value, 9)
-                parsed[req_s][float(percentile)] = scaled_result
+                parsed[label][float(percentile)] = scaled_result
             # parse detailed latency, only in wrk2 output
             for matches in re.findall(RegexLibrary.detailed_latency.value, single_wrk_output):
                 result, percentile = matches
                 percentile = float(percentile) * 100
                 scaled_result = round(float(result) * UnitMultiplier.ms.value, 9)
-                parsed[req_s][percentile] = scaled_result
+                parsed[label][percentile] = scaled_result
         if len(set(websites)) == 0:
             raise ValueError("No website detected")
         if len(set(websites)) > 1:


### PR DESCRIPTION
Solves #3 by adding `-n NAMES, --names NAMES` command line option to provide names for each curve in the order they are piped into `wkr2img`.